### PR TITLE
container class should wrap all row classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         <img src="./img/logo.png" class="img-responsive center-block">
         <h1>三哥下午茶價格計算器 (非官方)</h1>
     </div>
-    <div class="container">
+    < class="container">
         <div class="row">
             <div class="col-md-12">
                 <p id="choice" class="text-center"></p>
@@ -50,7 +50,6 @@
                 <p class="text-center">價格: </p>
             </div>
         </div>
-    </div>
     <div class="row">
         <div class="display_result">
             <div class="col-md-12">
@@ -385,7 +384,7 @@
             </div>
         </div>
     </div>
-
+    </div>
     <script>
         var choice = document.getElementById("choice");
         var A1 = document.getElementById("A1");

--- a/index.html
+++ b/index.html
@@ -50,342 +50,343 @@
                 <p class="text-center">價格: </p>
             </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="display_result">
-            <div class="col-md-12">
-                <p class="text-center"><input readonly id="display" class="text-center" type="text" name="display"
-                        value="0"></p>
-            </div>
-        </div>
-    </div>
-    <div class="calculator">
-        <div id="menu">
-            <div class="row">
-                <div class="col-md-6">
-                    <p class="text-center"><img src="./img/rice.png" class="img-responsive center-block">
-                        <input id="A1" type="button" value="茶餐A - 白飯">
-                    </p>
-                </div>
-                <div class="col-md-6">
-                    <p class="text-center"> <img src="./img/pork_rice.png" class="img-responsive center-block">
-                        <input id="A2" type="button" value="茶餐A - 三哥乍醬飯">
-                    </p>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-md-6">
-                    <p class="text-center"><img src="./img/rice_noodle_1.png" class="img-responsive center-block">
-                        <input id="B1" type="button" value="茶餐B - 迷你兩餸米線">
-                    </p>
-                </div>
-                <div class="col-md-6">
-                    <p class="text-center"><img src="./img/rice_noodle_2.png" class="img-responsive center-block">
-                        <input id="B2" type="button" value="茶餐B - 迷你三餸米線">
-                    </p>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-md-6">
-                    <p class="text-center"><img src="./img/sandwich_1.png" class="img-responsive center-block">
-                        <input id="C1" type="button" value="茶餐C - 烘肉桂焦糖三文治">
-                    </p>
-                </div>
-                <div class="col-md-6">
-                    <p class="text-center"><img src="./img/sandwich_2.png" class="img-responsive center-block">
-                        <input id="C2" type="button" value="茶餐C - 烘土匪芝士三文治">
-                    </p>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-md-6"><img src="./img/rice_ricenoodle.png" class="img-responsive center-block">
-                    <p class="text-center"><input id="D1" type="button" value="茶餐D - 白飯 + 迷你米線"></p>
-                </div>
-                <div class="col-md-6"><img src="./img/porkrice_ricenoodle.png" class="img-responsive center-block">
-                    <p class="text-center"><input id="D2" type="button" value="茶餐D - 三哥乍醬飯 + 迷你米線"></p>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-md-12"><img src="./img/big_ricenoodle.png" class="img-responsive center-block">
-                    <p class="text-center"><input id="E" type="button" value="茶餐E - 過小橋米線 ($46)"></p>
-                </div>
-            </div>
-        </div>
-        <div id="A1_1" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="A1_1_1" type="button" value="配清湯小食 + 飲品"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="A1_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($28)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="A1_1_3" type="button" value="配一人小食 + 飲品"></p>
-            </div>
-        </div>
-        <div id="A1_2" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="A1_2_1" type="button" value="雙餸清湯小食 ($25)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="A1_2_2" type="button" value="三餸清湯小食 ($29)"></p>
-            </div>
-        </div>
-        <div id="A1_3" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="A1_3_1" type="button" value="雙拼一人小食 ($32)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="A1_3_2" type="button" value="三拼一人小食 ($38)"></p>
-            </div>
-        </div>
-        <div id="A2_1" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="A2_1_1" type="button" value="配清湯小食 + 飲品"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="A2_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($33)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="A2_1_3" type="button" value="配一人小食 + 飲品"></p>
-            </div>
-        </div>
-        <div id="A2_2" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="A2_2_1" type="button" value="雙餸清湯小食 ($30)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="A2_2_2" type="button" value="三餸清湯小食 ($34)"></p>
-            </div>
-        </div>
-        <div id="A2_3" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="A2_3_1" type="button" value="雙拼一人小食 ($37)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="A2_3_2" type="button" value="三拼一人小食 ($43)"></p>
-            </div>
-        </div>
-        <div id="B1_soup" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="B1_clean" type="button" value="清湯底"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="B1_spicy" type="button" value="麻辣湯底 (+$1)"></p>
-            </div>
-        </div>
-        <div id="B1_1" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="B1_1_1" type="button" value="配清湯小食 + 飲品"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="B1_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($38)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="B1_1_3" type="button" value="配一人小食 + 飲品"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="B1_drinks_only" type="button" value="配飲品 ($29)"></p>
-            </div>
-        </div>
-        <div id="B1_2" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="B1_2_1" type="button" value="雙餸清湯小食 ($35)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="B1_2_2" type="button" value="三餸清湯小食 ($39)"></p>
-            </div>
-        </div>
-        <div id="B1_3" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="B1_3_1" type="button" value="雙拼一人小食 ($42)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="B1_3_2" type="button" value="三拼一人小食 ($48)"></p>
-            </div>
-        </div>
-        <div id="B2_soup" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="B2_clean" type="button" value="清湯底"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="B2_spicy" type="button" value="麻辣湯底 (+$1)"></p>
-            </div>
-        </div>
-        <div id="B2_1" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="B2_1_1" type="button" value="配清湯小食 + 飲品"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="B2_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($42)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="B2_1_3" type="button" value="配一人小食 + 飲品"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="B2_drinks_only" type="button" value="配飲品 ($33)"></p>
-            </div>
-        </div>
-        <div id="B2_2" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="B2_2_1" type="button" value="雙餸清湯小食 ($39)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="B2_2_2" type="button" value="三餸清湯小食 ($43)"></p>
-            </div>
-        </div>
-        <div id="B2_3" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="B2_3_1" type="button" value="雙拼一人小食 ($46)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="B2_3_2" type="button" value="三拼一人小食 ($52)"></p>
-            </div>
-        </div>
-        <div id="C1_1" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="C1_1_1" type="button" value="配清湯小食 + 飲品"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="C1_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($33)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="C1_1_3" type="button" value="配一人小食 + 飲品"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="C1_drinks_only" type="button" value="配飲品 ($21)"></p>
-            </div>
-        </div>
-        <div id="C1_2" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="C1_2_1" type="button" value="雙餸清湯小食 ($30)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="C1_2_2" type="button" value="三餸清湯小食 ($34)"></p>
-            </div>
-        </div>
-        <div id="C1_3" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="C1_3_1" type="button" value="雙拼一人小食 ($37)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="C1_3_2" type="button" value="三拼一人小食 ($43)"></p>
-            </div>
-        </div>
-        <div id="C2_1" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="C2_1_1" type="button" value="配清湯小食 + 飲品"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="C2_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($42)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="C2_1_3" type="button" value="配一人小食 + 飲品"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="C2_drinks_only" type="button" value="配飲品 ($30)"></p>
-            </div>
-        </div>
-        <div id="C2_2" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="C2_2_1" type="button" value="雙餸清湯小食 ($39)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="C2_2_2" type="button" value="三餸清湯小食 ($43)"></p>
-            </div>
-        </div>
-        <div id="C2_3" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="C2_3_1" type="button" value="雙拼一人小食 ($46)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="C2_3_2" type="button" value="三拼一人小食 ($52)"></p>
-            </div>
-        </div>
-        <div id="D1_sides" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="D1_sides_2" type="button" value="雙餸 ($35)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="D1_sides_3" type="button" value="三餸 ($39)"></p>
-            </div>
-        </div>
-        <div id="D1_soup" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="D1_clean" type="button" value="清湯底"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="D1_spicy" type="button" value="麻辣湯底 (+$1)"></p>
-            </div>
-        </div>
-        <div id="D2_sides" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="D2_sides_2" type="button" value="雙餸 ($40)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="D2_sides_3" type="button" value="三餸 ($44)"></p>
-            </div>
-        </div>
-        <div id="D2_soup" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="D2_clean" type="button" value="清湯底"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="D2_spicy" type="button" value="麻辣湯底 (+$1)"></p>
-            </div>
-        </div>
-        <div id="E_soup" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="E_clean" type="button" value="清湯底"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="E_spicy" type="button" value="麻辣/煳辣/酸辣湯底 (+$1)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="E_tomato" type="button" value="番茄/(重慶)三哥酸辣湯底 (+$2)"></p>
-            </div>
-        </div>
-        <div id="E_noodle" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="E_rice_noodle" type="button" value="米線"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="E_potato_noodle" type="button" value="薯粉 (+$2)"></p>
-            </div>
-        </div>
-        <div id="drinks" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="hot" type="button" value="熱飲"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="cold" type="button" value="凍飲 / 汽水 (+$3)"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="special" type="button" value="特飲 (+$6)"></p>
-            </div>
-        </div>
-        <div id="location" class="row" style="display:none;">
-            <div class="col-md-12">
-                <p class="text-center"><input id="eatin" type="button" value="堂食"></p>
-            </div>
-            <div class="col-md-12">
-                <p class="text-center"><input id="takeaway" type="button" value="外賣 (+$2)"></p>
-            </div>
-        </div>
+
         <div class="row">
-            <div class="col-md-12">
-                <p class="text-center"><input id="reset" type="button" value="重選"></p>
+            <div class="display_result">
+                <div class="col-md-12">
+                    <p class="text-center"><input readonly id="display" class="text-center" type="text" name="display"
+                            value="0"></p>
+                </div>
             </div>
         </div>
-        <div class="author">
+        <div class="calculator">
+            <div id="menu">
+                <div class="row">
+                    <div class="col-md-6">
+                        <p class="text-center"><img src="./img/rice.png" class="img-responsive center-block">
+                            <input id="A1" type="button" value="茶餐A - 白飯">
+                        </p>
+                    </div>
+                    <div class="col-md-6">
+                        <p class="text-center"> <img src="./img/pork_rice.png" class="img-responsive center-block">
+                            <input id="A2" type="button" value="茶餐A - 三哥乍醬飯">
+                        </p>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-6">
+                        <p class="text-center"><img src="./img/rice_noodle_1.png" class="img-responsive center-block">
+                            <input id="B1" type="button" value="茶餐B - 迷你兩餸米線">
+                        </p>
+                    </div>
+                    <div class="col-md-6">
+                        <p class="text-center"><img src="./img/rice_noodle_2.png" class="img-responsive center-block">
+                            <input id="B2" type="button" value="茶餐B - 迷你三餸米線">
+                        </p>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-6">
+                        <p class="text-center"><img src="./img/sandwich_1.png" class="img-responsive center-block">
+                            <input id="C1" type="button" value="茶餐C - 烘肉桂焦糖三文治">
+                        </p>
+                    </div>
+                    <div class="col-md-6">
+                        <p class="text-center"><img src="./img/sandwich_2.png" class="img-responsive center-block">
+                            <input id="C2" type="button" value="茶餐C - 烘土匪芝士三文治">
+                        </p>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-6"><img src="./img/rice_ricenoodle.png" class="img-responsive center-block">
+                        <p class="text-center"><input id="D1" type="button" value="茶餐D - 白飯 + 迷你米線"></p>
+                    </div>
+                    <div class="col-md-6"><img src="./img/porkrice_ricenoodle.png" class="img-responsive center-block">
+                        <p class="text-center"><input id="D2" type="button" value="茶餐D - 三哥乍醬飯 + 迷你米線"></p>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-12"><img src="./img/big_ricenoodle.png" class="img-responsive center-block">
+                        <p class="text-center"><input id="E" type="button" value="茶餐E - 過小橋米線 ($46)"></p>
+                    </div>
+                </div>
+            </div>
+            <div id="A1_1" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A1_1_1" type="button" value="配清湯小食 + 飲品"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A1_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($28)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A1_1_3" type="button" value="配一人小食 + 飲品"></p>
+                </div>
+            </div>
+            <div id="A1_2" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A1_2_1" type="button" value="雙餸清湯小食 ($25)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A1_2_2" type="button" value="三餸清湯小食 ($29)"></p>
+                </div>
+            </div>
+            <div id="A1_3" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A1_3_1" type="button" value="雙拼一人小食 ($32)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A1_3_2" type="button" value="三拼一人小食 ($38)"></p>
+                </div>
+            </div>
+            <div id="A2_1" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A2_1_1" type="button" value="配清湯小食 + 飲品"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A2_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($33)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A2_1_3" type="button" value="配一人小食 + 飲品"></p>
+                </div>
+            </div>
+            <div id="A2_2" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A2_2_1" type="button" value="雙餸清湯小食 ($30)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A2_2_2" type="button" value="三餸清湯小食 ($34)"></p>
+                </div>
+            </div>
+            <div id="A2_3" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A2_3_1" type="button" value="雙拼一人小食 ($37)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="A2_3_2" type="button" value="三拼一人小食 ($43)"></p>
+                </div>
+            </div>
+            <div id="B1_soup" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B1_clean" type="button" value="清湯底"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B1_spicy" type="button" value="麻辣湯底 (+$1)"></p>
+                </div>
+            </div>
+            <div id="B1_1" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B1_1_1" type="button" value="配清湯小食 + 飲品"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B1_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($38)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B1_1_3" type="button" value="配一人小食 + 飲品"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B1_drinks_only" type="button" value="配飲品 ($29)"></p>
+                </div>
+            </div>
+            <div id="B1_2" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B1_2_1" type="button" value="雙餸清湯小食 ($35)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B1_2_2" type="button" value="三餸清湯小食 ($39)"></p>
+                </div>
+            </div>
+            <div id="B1_3" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B1_3_1" type="button" value="雙拼一人小食 ($42)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B1_3_2" type="button" value="三拼一人小食 ($48)"></p>
+                </div>
+            </div>
+            <div id="B2_soup" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B2_clean" type="button" value="清湯底"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B2_spicy" type="button" value="麻辣湯底 (+$1)"></p>
+                </div>
+            </div>
+            <div id="B2_1" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B2_1_1" type="button" value="配清湯小食 + 飲品"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B2_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($42)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B2_1_3" type="button" value="配一人小食 + 飲品"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B2_drinks_only" type="button" value="配飲品 ($33)"></p>
+                </div>
+            </div>
+            <div id="B2_2" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B2_2_1" type="button" value="雙餸清湯小食 ($39)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B2_2_2" type="button" value="三餸清湯小食 ($43)"></p>
+                </div>
+            </div>
+            <div id="B2_3" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B2_3_1" type="button" value="雙拼一人小食 ($46)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="B2_3_2" type="button" value="三拼一人小食 ($52)"></p>
+                </div>
+            </div>
+            <div id="C1_1" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C1_1_1" type="button" value="配清湯小食 + 飲品"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C1_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($33)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C1_1_3" type="button" value="配一人小食 + 飲品"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C1_drinks_only" type="button" value="配飲品 ($21)"></p>
+                </div>
+            </div>
+            <div id="C1_2" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C1_2_1" type="button" value="雙餸清湯小食 ($30)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C1_2_2" type="button" value="三餸清湯小食 ($34)"></p>
+                </div>
+            </div>
+            <div id="C1_3" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C1_3_1" type="button" value="雙拼一人小食 ($37)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C1_3_2" type="button" value="三拼一人小食 ($43)"></p>
+                </div>
+            </div>
+            <div id="C2_1" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C2_1_1" type="button" value="配清湯小食 + 飲品"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C2_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($42)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C2_1_3" type="button" value="配一人小食 + 飲品"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C2_drinks_only" type="button" value="配飲品 ($30)"></p>
+                </div>
+            </div>
+            <div id="C2_2" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C2_2_1" type="button" value="雙餸清湯小食 ($39)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C2_2_2" type="button" value="三餸清湯小食 ($43)"></p>
+                </div>
+            </div>
+            <div id="C2_3" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C2_3_1" type="button" value="雙拼一人小食 ($46)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="C2_3_2" type="button" value="三拼一人小食 ($52)"></p>
+                </div>
+            </div>
+            <div id="D1_sides" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="D1_sides_2" type="button" value="雙餸 ($35)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="D1_sides_3" type="button" value="三餸 ($39)"></p>
+                </div>
+            </div>
+            <div id="D1_soup" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="D1_clean" type="button" value="清湯底"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="D1_spicy" type="button" value="麻辣湯底 (+$1)"></p>
+                </div>
+            </div>
+            <div id="D2_sides" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="D2_sides_2" type="button" value="雙餸 ($40)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="D2_sides_3" type="button" value="三餸 ($44)"></p>
+                </div>
+            </div>
+            <div id="D2_soup" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="D2_clean" type="button" value="清湯底"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="D2_spicy" type="button" value="麻辣湯底 (+$1)"></p>
+                </div>
+            </div>
+            <div id="E_soup" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="E_clean" type="button" value="清湯底"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="E_spicy" type="button" value="麻辣/煳辣/酸辣湯底 (+$1)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="E_tomato" type="button" value="番茄/(重慶)三哥酸辣湯底 (+$2)"></p>
+                </div>
+            </div>
+            <div id="E_noodle" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="E_rice_noodle" type="button" value="米線"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="E_potato_noodle" type="button" value="薯粉 (+$2)"></p>
+                </div>
+            </div>
+            <div id="drinks" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="hot" type="button" value="熱飲"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="cold" type="button" value="凍飲 / 汽水 (+$3)"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="special" type="button" value="特飲 (+$6)"></p>
+                </div>
+            </div>
+            <div id="location" class="row" style="display:none;">
+                <div class="col-md-12">
+                    <p class="text-center"><input id="eatin" type="button" value="堂食"></p>
+                </div>
+                <div class="col-md-12">
+                    <p class="text-center"><input id="takeaway" type="button" value="外賣 (+$2)"></p>
+                </div>
+            </div>
             <div class="row">
                 <div class="col-md-12">
-                    <p class="text-center">By 薩詩</p>
-                    <p class="text-center">Contact: <a href="mailto:sarssee421@gmail.com">sarssee421@gmail.com</a></p>
+                    <p class="text-center"><input id="reset" type="button" value="重選"></p>
+                </div>
+            </div>
+            <div class="author">
+                <div class="row">
+                    <div class="col-md-12">
+                        <p class="text-center">By 薩詩</p>
+                        <p class="text-center">Contact: <a href="mailto:sarssee421@gmail.com">sarssee421@gmail.com</a>
+                        </p>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-
     <script>
         var choice = document.getElementById("choice");
         var A1 = document.getElementById("A1");

--- a/index.html
+++ b/index.html
@@ -50,343 +50,342 @@
                 <p class="text-center">價格: </p>
             </div>
         </div>
-
-        <div class="row">
-            <div class="display_result">
-                <div class="col-md-12">
-                    <p class="text-center"><input readonly id="display" class="text-center" type="text" name="display"
-                            value="0"></p>
-                </div>
+    </div>
+    <div class="row">
+        <div class="display_result">
+            <div class="col-md-12">
+                <p class="text-center"><input readonly id="display" class="text-center" type="text" name="display"
+                        value="0"></p>
             </div>
         </div>
-        <div class="calculator">
-            <div id="menu">
-                <div class="row">
-                    <div class="col-md-6">
-                        <p class="text-center"><img src="./img/rice.png" class="img-responsive center-block">
-                            <input id="A1" type="button" value="茶餐A - 白飯">
-                        </p>
-                    </div>
-                    <div class="col-md-6">
-                        <p class="text-center"> <img src="./img/pork_rice.png" class="img-responsive center-block">
-                            <input id="A2" type="button" value="茶餐A - 三哥乍醬飯">
-                        </p>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-md-6">
-                        <p class="text-center"><img src="./img/rice_noodle_1.png" class="img-responsive center-block">
-                            <input id="B1" type="button" value="茶餐B - 迷你兩餸米線">
-                        </p>
-                    </div>
-                    <div class="col-md-6">
-                        <p class="text-center"><img src="./img/rice_noodle_2.png" class="img-responsive center-block">
-                            <input id="B2" type="button" value="茶餐B - 迷你三餸米線">
-                        </p>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-md-6">
-                        <p class="text-center"><img src="./img/sandwich_1.png" class="img-responsive center-block">
-                            <input id="C1" type="button" value="茶餐C - 烘肉桂焦糖三文治">
-                        </p>
-                    </div>
-                    <div class="col-md-6">
-                        <p class="text-center"><img src="./img/sandwich_2.png" class="img-responsive center-block">
-                            <input id="C2" type="button" value="茶餐C - 烘土匪芝士三文治">
-                        </p>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-md-6"><img src="./img/rice_ricenoodle.png" class="img-responsive center-block">
-                        <p class="text-center"><input id="D1" type="button" value="茶餐D - 白飯 + 迷你米線"></p>
-                    </div>
-                    <div class="col-md-6"><img src="./img/porkrice_ricenoodle.png" class="img-responsive center-block">
-                        <p class="text-center"><input id="D2" type="button" value="茶餐D - 三哥乍醬飯 + 迷你米線"></p>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-md-12"><img src="./img/big_ricenoodle.png" class="img-responsive center-block">
-                        <p class="text-center"><input id="E" type="button" value="茶餐E - 過小橋米線 ($46)"></p>
-                    </div>
-                </div>
-            </div>
-            <div id="A1_1" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A1_1_1" type="button" value="配清湯小食 + 飲品"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A1_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($28)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A1_1_3" type="button" value="配一人小食 + 飲品"></p>
-                </div>
-            </div>
-            <div id="A1_2" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A1_2_1" type="button" value="雙餸清湯小食 ($25)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A1_2_2" type="button" value="三餸清湯小食 ($29)"></p>
-                </div>
-            </div>
-            <div id="A1_3" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A1_3_1" type="button" value="雙拼一人小食 ($32)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A1_3_2" type="button" value="三拼一人小食 ($38)"></p>
-                </div>
-            </div>
-            <div id="A2_1" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A2_1_1" type="button" value="配清湯小食 + 飲品"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A2_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($33)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A2_1_3" type="button" value="配一人小食 + 飲品"></p>
-                </div>
-            </div>
-            <div id="A2_2" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A2_2_1" type="button" value="雙餸清湯小食 ($30)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A2_2_2" type="button" value="三餸清湯小食 ($34)"></p>
-                </div>
-            </div>
-            <div id="A2_3" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A2_3_1" type="button" value="雙拼一人小食 ($37)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="A2_3_2" type="button" value="三拼一人小食 ($43)"></p>
-                </div>
-            </div>
-            <div id="B1_soup" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B1_clean" type="button" value="清湯底"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B1_spicy" type="button" value="麻辣湯底 (+$1)"></p>
-                </div>
-            </div>
-            <div id="B1_1" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B1_1_1" type="button" value="配清湯小食 + 飲品"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B1_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($38)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B1_1_3" type="button" value="配一人小食 + 飲品"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B1_drinks_only" type="button" value="配飲品 ($29)"></p>
-                </div>
-            </div>
-            <div id="B1_2" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B1_2_1" type="button" value="雙餸清湯小食 ($35)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B1_2_2" type="button" value="三餸清湯小食 ($39)"></p>
-                </div>
-            </div>
-            <div id="B1_3" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B1_3_1" type="button" value="雙拼一人小食 ($42)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B1_3_2" type="button" value="三拼一人小食 ($48)"></p>
-                </div>
-            </div>
-            <div id="B2_soup" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B2_clean" type="button" value="清湯底"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B2_spicy" type="button" value="麻辣湯底 (+$1)"></p>
-                </div>
-            </div>
-            <div id="B2_1" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B2_1_1" type="button" value="配清湯小食 + 飲品"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B2_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($42)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B2_1_3" type="button" value="配一人小食 + 飲品"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B2_drinks_only" type="button" value="配飲品 ($33)"></p>
-                </div>
-            </div>
-            <div id="B2_2" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B2_2_1" type="button" value="雙餸清湯小食 ($39)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B2_2_2" type="button" value="三餸清湯小食 ($43)"></p>
-                </div>
-            </div>
-            <div id="B2_3" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B2_3_1" type="button" value="雙拼一人小食 ($46)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="B2_3_2" type="button" value="三拼一人小食 ($52)"></p>
-                </div>
-            </div>
-            <div id="C1_1" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C1_1_1" type="button" value="配清湯小食 + 飲品"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C1_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($33)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C1_1_3" type="button" value="配一人小食 + 飲品"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C1_drinks_only" type="button" value="配飲品 ($21)"></p>
-                </div>
-            </div>
-            <div id="C1_2" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C1_2_1" type="button" value="雙餸清湯小食 ($30)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C1_2_2" type="button" value="三餸清湯小食 ($34)"></p>
-                </div>
-            </div>
-            <div id="C1_3" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C1_3_1" type="button" value="雙拼一人小食 ($37)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C1_3_2" type="button" value="三拼一人小食 ($43)"></p>
-                </div>
-            </div>
-            <div id="C2_1" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C2_1_1" type="button" value="配清湯小食 + 飲品"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C2_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($42)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C2_1_3" type="button" value="配一人小食 + 飲品"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C2_drinks_only" type="button" value="配飲品 ($30)"></p>
-                </div>
-            </div>
-            <div id="C2_2" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C2_2_1" type="button" value="雙餸清湯小食 ($39)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C2_2_2" type="button" value="三餸清湯小食 ($43)"></p>
-                </div>
-            </div>
-            <div id="C2_3" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C2_3_1" type="button" value="雙拼一人小食 ($46)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="C2_3_2" type="button" value="三拼一人小食 ($52)"></p>
-                </div>
-            </div>
-            <div id="D1_sides" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="D1_sides_2" type="button" value="雙餸 ($35)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="D1_sides_3" type="button" value="三餸 ($39)"></p>
-                </div>
-            </div>
-            <div id="D1_soup" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="D1_clean" type="button" value="清湯底"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="D1_spicy" type="button" value="麻辣湯底 (+$1)"></p>
-                </div>
-            </div>
-            <div id="D2_sides" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="D2_sides_2" type="button" value="雙餸 ($40)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="D2_sides_3" type="button" value="三餸 ($44)"></p>
-                </div>
-            </div>
-            <div id="D2_soup" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="D2_clean" type="button" value="清湯底"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="D2_spicy" type="button" value="麻辣湯底 (+$1)"></p>
-                </div>
-            </div>
-            <div id="E_soup" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="E_clean" type="button" value="清湯底"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="E_spicy" type="button" value="麻辣/煳辣/酸辣湯底 (+$1)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="E_tomato" type="button" value="番茄/(重慶)三哥酸辣湯底 (+$2)"></p>
-                </div>
-            </div>
-            <div id="E_noodle" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="E_rice_noodle" type="button" value="米線"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="E_potato_noodle" type="button" value="薯粉 (+$2)"></p>
-                </div>
-            </div>
-            <div id="drinks" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="hot" type="button" value="熱飲"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="cold" type="button" value="凍飲 / 汽水 (+$3)"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="special" type="button" value="特飲 (+$6)"></p>
-                </div>
-            </div>
-            <div id="location" class="row" style="display:none;">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="eatin" type="button" value="堂食"></p>
-                </div>
-                <div class="col-md-12">
-                    <p class="text-center"><input id="takeaway" type="button" value="外賣 (+$2)"></p>
+    </div>
+    <div class="calculator">
+        <div id="menu">
+            <div class="row">
+                <div class="col-md-6">
+                    <p class="text-center"><img src="./img/rice.png" class="img-responsive center-block">
+                        <input id="A1" type="button" value="茶餐A - 白飯">
+                    </p>
+                </div>
+                <div class="col-md-6">
+                    <p class="text-center"> <img src="./img/pork_rice.png" class="img-responsive center-block">
+                        <input id="A2" type="button" value="茶餐A - 三哥乍醬飯">
+                    </p>
                 </div>
             </div>
             <div class="row">
-                <div class="col-md-12">
-                    <p class="text-center"><input id="reset" type="button" value="重選"></p>
+                <div class="col-md-6">
+                    <p class="text-center"><img src="./img/rice_noodle_1.png" class="img-responsive center-block">
+                        <input id="B1" type="button" value="茶餐B - 迷你兩餸米線">
+                    </p>
+                </div>
+                <div class="col-md-6">
+                    <p class="text-center"><img src="./img/rice_noodle_2.png" class="img-responsive center-block">
+                        <input id="B2" type="button" value="茶餐B - 迷你三餸米線">
+                    </p>
                 </div>
             </div>
-            <div class="author">
-                <div class="row">
-                    <div class="col-md-12">
-                        <p class="text-center">By 薩詩</p>
-                        <p class="text-center">Contact: <a href="mailto:sarssee421@gmail.com">sarssee421@gmail.com</a>
-                        </p>
-                    </div>
+            <div class="row">
+                <div class="col-md-6">
+                    <p class="text-center"><img src="./img/sandwich_1.png" class="img-responsive center-block">
+                        <input id="C1" type="button" value="茶餐C - 烘肉桂焦糖三文治">
+                    </p>
+                </div>
+                <div class="col-md-6">
+                    <p class="text-center"><img src="./img/sandwich_2.png" class="img-responsive center-block">
+                        <input id="C2" type="button" value="茶餐C - 烘土匪芝士三文治">
+                    </p>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-6"><img src="./img/rice_ricenoodle.png" class="img-responsive center-block">
+                    <p class="text-center"><input id="D1" type="button" value="茶餐D - 白飯 + 迷你米線"></p>
+                </div>
+                <div class="col-md-6"><img src="./img/porkrice_ricenoodle.png" class="img-responsive center-block">
+                    <p class="text-center"><input id="D2" type="button" value="茶餐D - 三哥乍醬飯 + 迷你米線"></p>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-12"><img src="./img/big_ricenoodle.png" class="img-responsive center-block">
+                    <p class="text-center"><input id="E" type="button" value="茶餐E - 過小橋米線 ($46)"></p>
+                </div>
+            </div>
+        </div>
+        <div id="A1_1" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="A1_1_1" type="button" value="配清湯小食 + 飲品"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="A1_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($28)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="A1_1_3" type="button" value="配一人小食 + 飲品"></p>
+            </div>
+        </div>
+        <div id="A1_2" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="A1_2_1" type="button" value="雙餸清湯小食 ($25)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="A1_2_2" type="button" value="三餸清湯小食 ($29)"></p>
+            </div>
+        </div>
+        <div id="A1_3" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="A1_3_1" type="button" value="雙拼一人小食 ($32)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="A1_3_2" type="button" value="三拼一人小食 ($38)"></p>
+            </div>
+        </div>
+        <div id="A2_1" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="A2_1_1" type="button" value="配清湯小食 + 飲品"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="A2_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($33)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="A2_1_3" type="button" value="配一人小食 + 飲品"></p>
+            </div>
+        </div>
+        <div id="A2_2" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="A2_2_1" type="button" value="雙餸清湯小食 ($30)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="A2_2_2" type="button" value="三餸清湯小食 ($34)"></p>
+            </div>
+        </div>
+        <div id="A2_3" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="A2_3_1" type="button" value="雙拼一人小食 ($37)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="A2_3_2" type="button" value="三拼一人小食 ($43)"></p>
+            </div>
+        </div>
+        <div id="B1_soup" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="B1_clean" type="button" value="清湯底"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="B1_spicy" type="button" value="麻辣湯底 (+$1)"></p>
+            </div>
+        </div>
+        <div id="B1_1" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="B1_1_1" type="button" value="配清湯小食 + 飲品"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="B1_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($38)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="B1_1_3" type="button" value="配一人小食 + 飲品"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="B1_drinks_only" type="button" value="配飲品 ($29)"></p>
+            </div>
+        </div>
+        <div id="B1_2" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="B1_2_1" type="button" value="雙餸清湯小食 ($35)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="B1_2_2" type="button" value="三餸清湯小食 ($39)"></p>
+            </div>
+        </div>
+        <div id="B1_3" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="B1_3_1" type="button" value="雙拼一人小食 ($42)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="B1_3_2" type="button" value="三拼一人小食 ($48)"></p>
+            </div>
+        </div>
+        <div id="B2_soup" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="B2_clean" type="button" value="清湯底"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="B2_spicy" type="button" value="麻辣湯底 (+$1)"></p>
+            </div>
+        </div>
+        <div id="B2_1" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="B2_1_1" type="button" value="配清湯小食 + 飲品"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="B2_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($42)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="B2_1_3" type="button" value="配一人小食 + 飲品"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="B2_drinks_only" type="button" value="配飲品 ($33)"></p>
+            </div>
+        </div>
+        <div id="B2_2" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="B2_2_1" type="button" value="雙餸清湯小食 ($39)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="B2_2_2" type="button" value="三餸清湯小食 ($43)"></p>
+            </div>
+        </div>
+        <div id="B2_3" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="B2_3_1" type="button" value="雙拼一人小食 ($46)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="B2_3_2" type="button" value="三拼一人小食 ($52)"></p>
+            </div>
+        </div>
+        <div id="C1_1" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="C1_1_1" type="button" value="配清湯小食 + 飲品"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="C1_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($33)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="C1_1_3" type="button" value="配一人小食 + 飲品"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="C1_drinks_only" type="button" value="配飲品 ($21)"></p>
+            </div>
+        </div>
+        <div id="C1_2" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="C1_2_1" type="button" value="雙餸清湯小食 ($30)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="C1_2_2" type="button" value="三餸清湯小食 ($34)"></p>
+            </div>
+        </div>
+        <div id="C1_3" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="C1_3_1" type="button" value="雙拼一人小食 ($37)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="C1_3_2" type="button" value="三拼一人小食 ($43)"></p>
+            </div>
+        </div>
+        <div id="C2_1" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="C2_1_1" type="button" value="配清湯小食 + 飲品"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="C2_1_2" type="button" value="配十三香辣小食三寶 + 飲品 ($42)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="C2_1_3" type="button" value="配一人小食 + 飲品"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="C2_drinks_only" type="button" value="配飲品 ($30)"></p>
+            </div>
+        </div>
+        <div id="C2_2" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="C2_2_1" type="button" value="雙餸清湯小食 ($39)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="C2_2_2" type="button" value="三餸清湯小食 ($43)"></p>
+            </div>
+        </div>
+        <div id="C2_3" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="C2_3_1" type="button" value="雙拼一人小食 ($46)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="C2_3_2" type="button" value="三拼一人小食 ($52)"></p>
+            </div>
+        </div>
+        <div id="D1_sides" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="D1_sides_2" type="button" value="雙餸 ($35)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="D1_sides_3" type="button" value="三餸 ($39)"></p>
+            </div>
+        </div>
+        <div id="D1_soup" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="D1_clean" type="button" value="清湯底"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="D1_spicy" type="button" value="麻辣湯底 (+$1)"></p>
+            </div>
+        </div>
+        <div id="D2_sides" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="D2_sides_2" type="button" value="雙餸 ($40)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="D2_sides_3" type="button" value="三餸 ($44)"></p>
+            </div>
+        </div>
+        <div id="D2_soup" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="D2_clean" type="button" value="清湯底"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="D2_spicy" type="button" value="麻辣湯底 (+$1)"></p>
+            </div>
+        </div>
+        <div id="E_soup" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="E_clean" type="button" value="清湯底"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="E_spicy" type="button" value="麻辣/煳辣/酸辣湯底 (+$1)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="E_tomato" type="button" value="番茄/(重慶)三哥酸辣湯底 (+$2)"></p>
+            </div>
+        </div>
+        <div id="E_noodle" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="E_rice_noodle" type="button" value="米線"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="E_potato_noodle" type="button" value="薯粉 (+$2)"></p>
+            </div>
+        </div>
+        <div id="drinks" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="hot" type="button" value="熱飲"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="cold" type="button" value="凍飲 / 汽水 (+$3)"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="special" type="button" value="特飲 (+$6)"></p>
+            </div>
+        </div>
+        <div id="location" class="row" style="display:none;">
+            <div class="col-md-12">
+                <p class="text-center"><input id="eatin" type="button" value="堂食"></p>
+            </div>
+            <div class="col-md-12">
+                <p class="text-center"><input id="takeaway" type="button" value="外賣 (+$2)"></p>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <p class="text-center"><input id="reset" type="button" value="重選"></p>
+            </div>
+        </div>
+        <div class="author">
+            <div class="row">
+                <div class="col-md-12">
+                    <p class="text-center">By 薩詩</p>
+                    <p class="text-center">Contact: <a href="mailto:sarssee421@gmail.com">sarssee421@gmail.com</a></p>
                 </div>
             </div>
         </div>
     </div>
+
     <script>
         var choice = document.getElementById("choice");
         var A1 = document.getElementById("A1");


### PR DESCRIPTION
There is an x-driection overflow in the current mobile view.:
![Screenshot 2023-08-22 at 2 29 55 AM](https://github.com/sarssee421/samgor_tea/assets/11500136/8d0b446d-26db-42fa-b2e3-4123536da342)

In bootstrap, I guess you need to use rows within a container.
https://getbootstrap.com/docs/4.0/layout/grid/